### PR TITLE
Clean up "supported environments" readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Plugin integrating [Dolby.io Communications](https://dolby.io) with the Unreal Engine.
 
 ## Supported environments
-- Windows 10+
+- Windows 10+ (all UE versions)
 - macOS:
    - UE 4.27: latest Mojave
    - UE 5: latest Monterey

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 Plugin integrating [Dolby.io Communications](https://dolby.io) with the Unreal Engine.
 
 ## Supported environments
-- Unreal Engine 4.27.2 and 5.0.3
-- Windows 10 and macOS 12
+- Windows 10+
+- macOS:
+   - UE 4.27: latest Mojave
+   - UE 5: latest Monterey
 
 Note: If you want to use the plugin on macOS, see our [advice](#macos-advice).
 


### PR DESCRIPTION
## This PR closes the following issue:
closes #52 

## Changes made:
- Supported operating systems for the plugin are:
```
- Windows 10+
- macOS:
       - UE 4.27: latest Mojave
       - UE 5: latest Monterey
```