### PR TITLE
Move error handler

### DIFF
--- a/DolbyIO/Source/Public/DolbyIOSubsystem.h
+++ b/DolbyIO/Source/Public/DolbyIOSubsystem.h
@@ -211,4 +211,20 @@ private:
 
 	FTimerHandle LocationTimerHandle;
 	FTimerHandle RotationTimerHandle;
+
+	class FErrorHandler final
+	{
+	public:
+		FErrorHandler(UDolbyIOSubsystem& DolbyIOSubsystem, int Line);
+
+		void operator()(std::exception_ptr&& ExcPtr) const;
+		void HandleError() const;
+
+	private:
+		void HandleError(TFunction<void()> Callee) const;
+		void LogException(const FString& Type, const FString& What) const;
+
+		UDolbyIOSubsystem& DolbyIOSubsystem;
+		int Line;
+	};
 };


### PR DESCRIPTION
This allows handling errors by actually doing stuff.

If you set a token that is JWT-parsable but still incorrect, you will not be able to initialize the SDK unless you restart the game, because the SDK will not be null but it will be unusable. I had to handle the token exception by clearing the SDK and therefore decided to move FErrorHandler into UDolbyIOSubsystem.