### PR TITLE
Fix bind/unbind material logic

### DIFF
--- a/DolbyIO/Source/Private/DolbyIOSubsystem.cpp
+++ b/DolbyIO/Source/Private/DolbyIOSubsystem.cpp
@@ -694,16 +694,17 @@ void UDolbyIOSubsystem::ChangeScreenshareParameters(EDolbyIOScreenshareEncoderHi
 
 void UDolbyIOSubsystem::BindMaterial(UMaterialInstanceDynamic* Material, const FString& VideoTrackID)
 {
-	for (const auto& Sink : VideoSinks)
+	for (auto& Sink : VideoSinks)
 	{
-		if (Sink.Key == VideoTrackID)
-		{
-			Sink.Value->BindMaterial(Material);
-		}
-		else
+		if (Sink.Key != VideoTrackID)
 		{
 			Sink.Value->UnbindMaterial(Material);
 		}
+	}
+
+	if (const std::shared_ptr<DolbyIO::FVideoSink>* Sink = VideoSinks.Find(VideoTrackID))
+	{
+		(*Sink)->BindMaterial(Material);
 	}
 }
 

--- a/DolbyIO/Source/Private/DolbyIOVideoSink.cpp
+++ b/DolbyIO/Source/Private/DolbyIOVideoSink.cpp
@@ -73,6 +73,16 @@ namespace DolbyIO
 			          });
 			return Ret;
 		}
+
+		void UnbindMaterialImpl(UMaterialInstanceDynamic& Material)
+		{
+			static UTexture2D* EmptyTexture = nullptr;
+			if (!EmptyTexture)
+			{
+				EmptyTexture = CreateEmptyTexture();
+			}
+			Material.SetTextureParameterValue(TexParamName, EmptyTexture);
+		}
 	}
 
 	FVideoSink::FVideoSink(const FString& VideoTrackID) : Texture(CreateEmptyTexture()), VideoTrackID(VideoTrackID) {}
@@ -102,25 +112,25 @@ namespace DolbyIO
 	{
 		if (Materials.Remove(Material) && IsValid(Material))
 		{
-			static UTexture2D* EmptyTexture = nullptr;
-			if (!EmptyTexture)
-			{
-				EmptyTexture = CreateEmptyTexture();
-			}
 			DLB_UE_LOG("Unbinding material %u from video track ID %s texture %u", Material->GetUniqueID(),
 			           *VideoTrackID, Texture->GetUniqueID());
-			AsyncTask(ENamedThreads::GameThread,
-			          [Material] { Material->SetTextureParameterValue(TexParamName, EmptyTexture); });
+			UnbindMaterialImpl(*Material);
 		}
 	}
 
 	void FVideoSink::UnbindAllMaterials()
 	{
-		TArray<UMaterialInstanceDynamic*> MaterialsArray = Materials.Array();
-		for (UMaterialInstanceDynamic* Material : MaterialsArray)
-		{
-			UnbindMaterial(Material);
-		}
+		AsyncTask(ENamedThreads::GameThread,
+		          [MaterialsArray = Materials.Array()]
+		          {
+			          for (UMaterialInstanceDynamic* Material : MaterialsArray)
+			          {
+				          if (IsValid(Material))
+				          {
+					          UnbindMaterialImpl(*Material);
+				          }
+			          }
+		          });
 	}
 
 	void FVideoSink::handle_frame(const video_frame& VideoFrame)


### PR DESCRIPTION
Fixes an issue where binding a material that was already bound to another track could cause a situation where it was first bound to the new material and then unbound from the previous one. Since unbinding means that the material is set to hold a 1x1 black texture it needs to be performed first, before the new binding.